### PR TITLE
Disable autoindent in IPython

### DIFF
--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -14,7 +14,7 @@ if has('nvim')
     " Python
     au VimEnter,BufRead,BufNewFile *.py,
           \ if executable('ipython') |
-          \   call neoterm#repl#set('ipython') |
+          \   call neoterm#repl#set('ipython --no-autoindent') |
           \ elseif executable('python') |
           \   call neoterm#repl#set('python') |
           \ end


### PR DESCRIPTION
This prevents indented code from being mangled upon `TREPLSend`ing to IPython, by starting IPython with the "autoindent" option already disabled.
